### PR TITLE
Update 2021-08-12-sshfs.md

### DIFF
--- a/_posts/2021-08-12-sshfs.md
+++ b/_posts/2021-08-12-sshfs.md
@@ -51,7 +51,8 @@ Otherwise, all you'll need to do is **open a terminal** and run `sudo apt instal
 
 ### macOS
 1. **Install Homebrew** if you don't have it already by following the instructions [here](https://brew.sh){: target="_blank"}.
-1. **Run** `brew install sshfs` in your terminal and follow any steps which pop up.
+2. **Install MacFUSE** Run `brew install --cask macfuse` in your terminal. Go to System Preferences → Security & Privacy, enable the new system extension, then restart.
+3. **Install sshfs** Run `brew install gromgit/fuse/sshfs-mac` in your terminal and follow any steps which pop up.
 
 ## Mounting your CSE home directory
 
@@ -64,7 +65,7 @@ Yay! Your CSE files should now be accessible in the `~/cse` directory! You can n
 
 [^4]: Make sure to have the 'Remote - WSL' extension installed in VS Code. There's also a weird WSL bug where the `code` command may not work if you're in the `~/cse` directory, so you may need to run it from outside.
 
-**Once you're done working**, you should unmount the CSE filesystem. To do this, run `fusermount -u ~/cse` [^5].
+**Once you're done working**, you should unmount the CSE filesystem. To do this, run `fusermount -u ~/cse` on Linux, or `unmount -f ~/cse` on macOS[^5].
 
 [^5]: It's not the worst thing in the world if you forget/are unable to unmount, but you'll be using up some resources both on your own computer as well as CSE computers.
 


### PR DESCRIPTION
## MacOS specific changes
1. `brew install sshfs` doesn't work as [Homebrew has disabled it](https://github.com/osxfuse/osxfuse/issues/801), so I've replaced it with another developer's cask. macFUSE must be installed as a dependency first via `brew install --cask macfuse`.
2. umount is used to unmount on macOS 😄 

Thanks for the guide! Super helpful.